### PR TITLE
discover: promote agent--claude-smith to ranked value tier

### DIFF
--- a/DISCOVERY.md
+++ b/DISCOVERY.md
@@ -1,0 +1,46 @@
+# Discovery: agent--claude-smith
+
+**Date:** 2026-06-22
+**Verdict:** VALUE FOUND — promote to ranked tier.
+**Build state at discovery:** green (`tsc --noEmit` clean, 320 tests passing across 11 files).
+
+## Value Thesis
+
+`agent--claude-smith` is not a skeleton — it is a working, 6,281-LOC, 320-test multi-agent
+orchestration system on the Claude Agent SDK, with real exports (`createOrchestrator`,
+`Orchestrator`, `AgentRegistry`, `SessionManager`, `SecretResolver`) and four built-in agents.
+Its highest *latent* value is not the orchestrator (which overlaps the sibling `agentic-titan`)
+but the **self-contained, bypass-resistant security layer** in `src/security/command-validator.ts`:
+`validateCommand()` (14 categories of dangerous-shell-pattern detection — destructive deletes,
+privilege escalation, fork bombs, `curl|sh` RCE, container escapes, history-tampering — using
+normalized pattern matching that survives quote/variable/pipeline obfuscation), plus
+`validateWritePath()` (deny-list for `/etc`, `~/.ssh/authorized_keys`, shell rc files, credential
+stores) and `validateSessionId()` (path-traversal prevention). It is dependency-free, covered by a
+dedicated 31-case command-injection test suite, and solves a problem every agentic repo in the
+estate faces independently: how to let an LLM run shell commands without letting it run *those*
+shell commands. With ~89 active repos, ~107 CI workflows, and multiple agent-spawning siblings
+(`agentic-titan`, `universal-node-network`, `reverse-engine-recursive-run`), a hardened, tested,
+reusable command-guardrail is the single most leverageable asset here — a horizontal safety
+primitive the rest of ORGAN-IV can consume rather than re-implement as ad-hoc regex. That is the
+discovered value: this repo is the estate's natural home for **agent execution guardrails**.
+
+## Highest-Value Asset (concrete)
+
+- **`src/security/command-validator.ts`** — reusable guardrail library (validateCommand /
+  validateWritePath / validateSessionId), zero runtime deps, 31 dedicated security tests.
+- Supporting capability: the orchestrator's session persistence, cycle-free spawn graphs, and
+  self-correction/retry hooks make it a usable reference implementation for governed agent spawning.
+
+## Single Best Concrete First Task
+
+**Extract the security layer into a standalone, importable guardrail package/export**
+(e.g. an `@organvm/agent-guardrails` entrypoint or a published sub-export exposing
+`validateCommand`, `validateWritePath`, `validateSessionId` + the 31-case test suite) so sibling
+agentic repos can `import { validateCommand }` instead of re-implementing shell-safety regexes.
+This converts an internal module into an estate-wide reusable asset with one focused, low-risk PR.
+
+## Why not archival
+
+Archival was considered and rejected: the code builds green, has 320 passing tests, exposes a real
+public API, and contains a differentiated, broadly-reusable safety primitive. Leaving it dark would
+mean every other agent-spawning repo keeps re-solving command validation worse.

--- a/value-repos.json
+++ b/value-repos.json
@@ -1,0 +1,13 @@
+{
+  "description": "Ranked tier of organvm repositories with discovered latent value. Repos here have a written value thesis (see each repo's DISCOVERY.md) and are eligible for build-out.",
+  "repos": [
+    {
+      "repo": "organvm/agent--claude-smith",
+      "organ": "ORGAN-IV",
+      "discovered": "2026-06-22",
+      "thesis": "Working 6,281-LOC / 320-test multi-agent orchestrator whose highest latent value is a self-contained, bypass-resistant agent execution guardrail (validateCommand / validateWritePath / validateSessionId) reusable across the estate's agent-spawning repos.",
+      "primary_asset": "src/security/command-validator.ts",
+      "first_task": "Extract the security layer into a standalone importable guardrail package/export (@organvm/agent-guardrails) so sibling agentic repos can import validateCommand instead of re-implementing shell-safety regexes."
+    }
+  ]
+}


### PR DESCRIPTION
## Discovery: agent--claude-smith

Auto-discovery pass (DISCOVER-organvm-agent--claude-smith, 2026-06-22). This repo had no ranked value; this PR records the discovered value and promotes it.

### Verdict: VALUE FOUND
Not archival. The repo is a working, **6,281-LOC, 320-test** multi-agent orchestrator on the Claude Agent SDK with real exports and four built-in agents. Build is green (`tsc --noEmit` clean, 320/320 tests passing).

### Highest latent value
The self-contained, bypass-resistant **agent execution guardrail** in `src/security/command-validator.ts`:
- `validateCommand()` — 14 categories of dangerous-shell detection (destructive deletes, privilege escalation, fork bombs, `curl|sh` RCE, container escapes, history tampering) via obfuscation-resistant normalized pattern matching
- `validateWritePath()` — deny-list for `/etc`, `~/.ssh`, shell rc, credential stores
- `validateSessionId()` — path-traversal prevention
- Zero runtime deps, 31 dedicated security tests

Every agent-spawning sibling in ORGAN-IV (`agentic-titan`, `universal-node-network`, `reverse-engine-recursive-run`) faces this same shell-safety problem independently. This repo is the estate's natural home for a shared guardrail primitive.

### Changes
- Add `DISCOVERY.md` (full value thesis)
- Append `organvm/agent--claude-smith` to `value-repos.json` (ranked tier)

### Single best concrete first task
**Extract the security layer into a standalone importable guardrail package/export** (`@organvm/agent-guardrails`) exposing `validateCommand` / `validateWritePath` / `validateSessionId` + the 31-case test suite, so sibling repos import it instead of re-implementing shell-safety regexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)